### PR TITLE
Log file for site computation tracking bugfix

### DIFF
--- a/scalefex_main.py
+++ b/scalefex_main.py
@@ -163,7 +163,6 @@ class Process_HighContentImaging_screen:
                         
       
                         center_of_mass=np.array([list(row) + [n] for n,row in enumerate(center_of_mass)])
-                        live_cells=len(center_of_mass)
                       
                     else:
                         


### PR DESCRIPTION
the "site tracking" logfile now uses the same ids from the coordinate csv (if supplied)