### PR TITLE
standardizing site-tracking file format

### DIFF
--- a/data_query/query_functions_local.py
+++ b/data_query/query_functions_local.py
@@ -103,10 +103,11 @@ def query_data(exp_folder,pattern,plate_identifiers=('_CCU384_','_'),exts=('tiff
 
     print("retrieving files from ", (exp_folder))
     # getting plates that match plate_identifiers
+    
     plate_identifiers = list(plate_identifiers)
-    if plate_identifiers[0] == '':
+    if plate_identifiers[0] in ('','/'):
         plate_identifiers[0] = '^'
-    if plate_identifiers[1] == '':
+    if plate_identifiers[1] == ('','/'):
         plate_identifiers[1] = '$'
     plate_identifiers = tuple(plate_identifiers)
     # match plate subdir 

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -34,7 +34,7 @@ segmenting_function: 'Nuclei_segmentation.nuclei_location_extraction'
 save_coordinates: True # if true, saves a csv file with the coordinates for cells for each plate
 min_cell_size: 200 # min area threshold for mask (any object with smaller area will be removed)
 max_cell_size: 100000 # max area threshold for mask (any object with bigger area will be removed)
-visualization: False # if true, the segmentation masks of the entire field will be visualizaed (using matplotlib). NOTE: we suggest to visualize the masks for testing, but to turn it off during the processing of large screens
+visualization: False # if true, the segmentation masks of the entire field will be visualized (using matplotlib). NOTE: we suggest to visualize the masks for testing, but to turn it off during the processing of large screens
 
 ## Scalefex settings
 RNA_channel: 'ch5' # channel with RNA stain (if any)


### PR DESCRIPTION
Standardizing site-tracking file format. Now has the following columns for the local version (@Gabcomolet will open a PR for the AWS code so it matches):
```
plate, well, site, subset, file_path, total_count, computed_count, on_edge_count, fail_count, computed_ids, on_edge_ids, fail_ids
```

Also refactored code to change `field` to `site` for variables/file names, since that's the convention we use for everything else.
