### PR TITLE
time-stamp formatting fix

### DIFF
--- a/scalefex_main.py
+++ b/scalefex_main.py
@@ -44,7 +44,7 @@ class Process_HighContentImaging_screen:
 
     def run(self):
 
-        start_time = datetime.now()
+        start_time = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         
         
         files = data_query.query_functions_local.query_data(self.parameters['exp_folder'], self.parameters['pattern'],plate_identifiers=self.parameters['plate_identifiers'],


### PR DESCRIPTION
time-stamp for file naming incompatible with Windows (see #53). I refactored to remove colons and spaces
closes #53 
